### PR TITLE
Implement an endpoint to get all messages by chatId

### DIFF
--- a/server/src/modules/messages/message.controller.ts
+++ b/server/src/modules/messages/message.controller.ts
@@ -1,0 +1,23 @@
+import { MessageService } from './message.service';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '../user/auth/auth.guard';
+import { Message } from './entities/message.entity';
+
+@UseGuards(AuthGuard)
+@Controller('messages')
+export class MessageController {
+  constructor(private readonly messageService: MessageService) {}
+
+  @Get('/chats/:chatId')
+  async getMessagesByChatId(
+    @Param('chatId', ParseIntPipe) chatId: number,
+  ): Promise<Message[]> {
+    return await this.messageService.getMessagesByChatId(chatId);
+  }
+}

--- a/server/src/modules/messages/message.service.spec.ts
+++ b/server/src/modules/messages/message.service.spec.ts
@@ -1,0 +1,116 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { MessageService } from './message.service';
+import { Message } from './entities/message.entity';
+import { ChatService } from '../chat/chat.service';
+import { Repository } from 'typeorm';
+import { User } from '../user/entities/user.entity';
+import { Chat } from '../chat/entities/chat.entity';
+
+describe('MessageService → getMessagesByChatId', () => {
+  let service: MessageService;
+  let messageRepo: jest.Mocked<Repository<Message>>;
+  let chatService: jest.Mocked<ChatService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessageService,
+        {
+          provide: getRepositoryToken(Message),
+          useValue: {
+            find: jest.fn(),
+          },
+        },
+        {
+          provide: ChatService,
+          useValue: {
+            findById: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<MessageService>(MessageService);
+    messageRepo = module.get(getRepositoryToken(Message));
+    chatService = module.get(ChatService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should return messages ordered by created_at ASC for a given chatId', async () => {
+    const chatId = 5;
+
+    chatService.findById.mockResolvedValue({ id: chatId } as Chat);
+
+    const mockMessages: Message[] = [
+      {
+        id: 1,
+        message: 'Hello!',
+        created_at: new Date('2026-03-01'),
+        updated_at: new Date('2026-03-01'),
+        sender: { id: 10, username: 'alice' } as User,
+        chat: { id: chatId } as Chat,
+      } as Message,
+      {
+        id: 2,
+        message: 'Hi there!',
+        created_at: new Date('2026-03-02'),
+        updated_at: new Date('2026-03-02'),
+        sender: { id: 20, username: 'bob' } as User,
+        chat: { id: chatId } as Chat,
+      } as Message,
+    ];
+
+    messageRepo.find.mockResolvedValue(mockMessages);
+
+    const result = await service.getMessagesByChatId(chatId);
+
+    expect(chatService.findById).toHaveBeenCalledWith(chatId);
+    expect(messageRepo.find).toHaveBeenCalledWith({
+      where: { chat: { id: chatId } },
+      relations: ['sender'],
+      order: { created_at: 'ASC' },
+    });
+    expect(result).toEqual(mockMessages);
+    expect(result).toHaveLength(2);
+  });
+
+  it('should return an empty array when no messages exist for the chatId', async () => {
+    const chatId = 99;
+
+    chatService.findById.mockResolvedValue({ id: chatId } as Chat);
+    messageRepo.find.mockResolvedValue([]);
+
+    const result = await service.getMessagesByChatId(chatId);
+
+    expect(chatService.findById).toHaveBeenCalledWith(chatId);
+    expect(messageRepo.find).toHaveBeenCalledWith({
+      where: { chat: { id: chatId } },
+      relations: ['sender'],
+      order: { created_at: 'ASC' },
+    });
+    expect(result).toEqual([]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should throw NotFoundException when the chat does not exist', async () => {
+    const chatId = 999;
+
+    chatService.findById.mockResolvedValue(null);
+
+    await expect(service.getMessagesByChatId(chatId)).rejects.toThrow(
+      NotFoundException,
+    );
+    expect(chatService.findById).toHaveBeenCalledWith(chatId);
+    expect(messageRepo.find).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/messages/message.service.ts
+++ b/server/src/modules/messages/message.service.ts
@@ -1,14 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Message } from './entities/message.entity';
 import { CreateMessageDto } from './dtos/CreateMessage.dto';
+import { ChatService } from '../chat/chat.service';
 
 @Injectable()
 export class MessageService {
   constructor(
     @InjectRepository(Message)
     private readonly messageRepository: Repository<Message>,
+    private readonly chatService: ChatService,
   ) {}
 
   /**
@@ -31,6 +33,24 @@ export class MessageService {
     return this.messageRepository.findOneOrFail({
       where: { id: saved.id },
       relations: ['sender', 'chat'],
+    });
+  }
+
+  /**
+   * Retrieves all messages for a given chat ID, including sender information, ordered by creation time ascending.
+   * @param chatId - The ID of the chat for which to retrieve messages.
+   * @returns an array of Message entities with sender relations, ordered by created_at ascending.
+   */
+  async getMessagesByChatId(chatId: number): Promise<Message[]> {
+    const chat = await this.chatService.findById(chatId);
+    if (!chat) {
+      throw new NotFoundException(`Chat with ID ${chatId} not found`);
+    }
+
+    return this.messageRepository.find({
+      where: { chat: { id: chatId } },
+      relations: ['sender'],
+      order: { created_at: 'ASC' },
     });
   }
 }

--- a/server/src/modules/messages/messages.module.ts
+++ b/server/src/modules/messages/messages.module.ts
@@ -5,10 +5,12 @@ import { MessageReaction } from './entities/message_reaction.entity';
 import { MessageGateway } from './message.gateway';
 import { MessageService } from './message.service';
 import { ChatModule } from '../chat/chat.module';
+import { MessageController } from './message.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Message, MessageReaction]), ChatModule],
   providers: [MessageGateway, MessageService],
+  controllers: [MessageController],
   exports: [TypeOrmModule, MessageService],
 })
 export class MessagesModule {}


### PR DESCRIPTION
This PR closes #67.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve messages from a specific chat with authentication protection. Messages are returned in chronological order for improved readability and user experience.

* **Tests**
  * Added comprehensive unit test coverage for message retrieval, including successful retrieval, empty chat scenarios, and error handling for non-existent chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->