### PR TITLE
Make join chat button disabled when current user is already a chat member of chat members have reached the limit

### DIFF
--- a/client/src/modules/chats/api/chat.ts
+++ b/client/src/modules/chats/api/chat.ts
@@ -10,3 +10,8 @@ export const getChatById = async (chatId: number): Promise<ChatType> => {
   const res = await request.get(`/chats/${chatId}`);
   return res.data;
 };
+
+export const getChatByPostId = async (postId: number): Promise<ChatType | null> => {
+  const res = await request.get(`/chats/posts/${postId}`);
+  return res.data;
+};

--- a/client/src/modules/posts/components/Post.tsx
+++ b/client/src/modules/posts/components/Post.tsx
@@ -20,6 +20,7 @@ import { convertToDateString } from "@/modules/shared/lib";
 import User from "@/modules/shared/components/User";
 import { useQuery } from "@tanstack/react-query";
 import { isPostJoinRequestForCurrentPostByUserId } from "@/modules/notification/api/notification";
+import { getChatByPostId } from "@/modules/chats/api/chat";
 
 const MAX_DESCRIPTION_LENGTH = 90;
 
@@ -45,6 +46,14 @@ const Post = ({ post }: PostProps) => {
     queryKey: ["notification-status", token, post.id],
     queryFn: () => isPostJoinRequestForCurrentPostByUserId(userId!, post.id),
   });
+
+  const { data: chat } = useQuery({
+    queryKey: ["chat-by-post", post.id],
+    queryFn: () => getChatByPostId(post.id),
+  });
+
+  const isChatMember = chat?.members?.some((member) => member.user.id === userId) ?? false;
+  const isChatFull = chat ? chat.members.length >= chat.max_members : false;
 
   const handleJoinRequest = () => {
     socket.emit("joinRequest", {
@@ -78,10 +87,10 @@ const Post = ({ post }: PostProps) => {
           <CardAction>
             <Button
               onClick={handleJoinRequest}
-              disabled={isPostOwner || notificationStatus}
+              disabled={isPostOwner || notificationStatus || isChatMember || isChatFull}
               className="body-semibold h-6 w-16 cursor-pointer rounded-lg bg-[#99dfc4] text-[#2d634e] hover:bg-[#acf0d6]"
             >
-              {"Join"}
+              Join
             </Button>
           </CardAction>
         </CardHeader>

--- a/client/src/modules/socket/context/SocketContext.tsx
+++ b/client/src/modules/socket/context/SocketContext.tsx
@@ -50,6 +50,7 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
     socket.on("notification_join_response", (data) => {
       queryClient.invalidateQueries({ queryKey: ["notifications", token] });
       queryClient.invalidateQueries({ queryKey: ["notification-status", token, data.notification.postId] });
+      queryClient.invalidateQueries({ queryKey: ["chat-by-post", data.notification.postId] });
     });
 
     /**

--- a/server/src/modules/chat/chat.controller.spec.ts
+++ b/server/src/modules/chat/chat.controller.spec.ts
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatController } from './chat.controller';
+import { ChatService } from './chat.service';
+import { Chat } from './entities/chat.entity';
+
+describe('ChatController → getChatByPostId', () => {
+  let controller: ChatController;
+  let chatService: jest.Mocked<ChatService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChatController],
+      providers: [
+        {
+          provide: ChatService,
+          useValue: {
+            findByPostId: jest.fn(),
+            findById: jest.fn(),
+            getAllChatsByUserId: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ChatController>(ChatController);
+    chatService = module.get(ChatService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getChatByPostId', () => {
+    const postId = 15;
+
+    const mockChat = {
+      id: 100,
+      title: 'Trip to mountains',
+      max_members: 4,
+      created_at: new Date('2025-03-10'),
+      posts: [],
+      members: [
+        {
+          id: 300,
+          joined_at: new Date(),
+          user: { id: 10, username: 'alice' },
+        },
+        {
+          id: 301,
+          joined_at: new Date(),
+          user: { id: 11, username: 'carol' },
+        },
+      ],
+      messages: [],
+    } as unknown as Chat;
+
+    it('should return the chat associated with the given postId', async () => {
+      chatService.findByPostId.mockResolvedValue(mockChat);
+
+      const result = await controller.getChatByPostId(postId);
+
+      expect(chatService.findByPostId).toHaveBeenCalledWith(postId);
+      expect(result).toEqual(mockChat);
+    });
+
+    it('should return null when no chat is associated with the postId', async () => {
+      chatService.findByPostId.mockResolvedValue(null);
+
+      const result = await controller.getChatByPostId(999);
+
+      expect(chatService.findByPostId).toHaveBeenCalledWith(999);
+      expect(result).toBeNull();
+    });
+
+    it('should include members with user details in the returned chat', async () => {
+      chatService.findByPostId.mockResolvedValue(mockChat);
+
+      const result = await controller.getChatByPostId(postId);
+
+      expect(result).not.toBeNull();
+      expect(result!.members).toHaveLength(2);
+      expect(result!.members[0].user).toHaveProperty('id');
+      expect(result!.members[0].user).toHaveProperty('username');
+    });
+  });
+});

--- a/server/src/modules/chat/chat.controller.ts
+++ b/server/src/modules/chat/chat.controller.ts
@@ -15,11 +15,11 @@ import { Chat } from './entities/chat.entity';
 export class ChatController {
   constructor(private readonly chatService: ChatService) {}
 
-  @Get(':id')
-  async getChatById(
-    @Param('id', ParseIntPipe) id: number,
+  @Get('posts/:postId')
+  async getChatByPostId(
+    @Param('postId', ParseIntPipe) postId: number,
   ): Promise<Chat | null> {
-    return await this.chatService.findById(id);
+    return await this.chatService.findByPostId(postId);
   }
 
   @Get('users/:userId')
@@ -27,5 +27,12 @@ export class ChatController {
     @Param('userId', ParseIntPipe) userId: number,
   ): Promise<ChatWithOwner[]> {
     return await this.chatService.getAllChatsByUserId(userId);
+  }
+
+  @Get(':id')
+  async getChatById(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<Chat | null> {
+    return await this.chatService.findById(id);
   }
 }

--- a/server/src/modules/chat/chat.service.ts
+++ b/server/src/modules/chat/chat.service.ts
@@ -62,6 +62,8 @@ export class ChatService {
     return this.chatRepository
       .createQueryBuilder('chat')
       .innerJoin('chat.posts', 'post', 'post.id = :postId', { postId })
+      .leftJoinAndSelect('chat.members', 'member')
+      .leftJoinAndSelect('member.user', 'user')
       .getOne();
   }
 


### PR DESCRIPTION
This PR closes #83.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added chat retrieval by post ID for direct access to post-related chat information
* Join button now respects chat capacity and membership status, disabling when appropriate

## Tests
* Introduced unit tests for new chat retrieval functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->